### PR TITLE
Fix error handling on postTranslateJobs call

### DIFF
--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -259,7 +259,8 @@ class Gengo(object):
             if 'opstat' in results and results['opstat'] != 'ok':
                 # In cases of multiple errors, the keys for results['err']
                 # will be the job IDs.
-                if not 'msg' and 'code' in results['err']:
+                if 'msg' not in results['err'] and\
+                        'code' not in results['err']:
                     concatted_msg = ''
                     for job_key, msg_code_list in results['err'].iteritems():
                         concatted_msg += '<%s: %s> ' % \


### PR DESCRIPTION
The 'if' clause always evaluated False, regardless of the response from Gengo
API. This way, when postTranslationJobs returned an error, the library always
raised a KeyError, instead of a proper one. (See the diff, it's a one-liner)
