### PR TITLE
Shebang must be in first of file

### DIFF
--- a/examples/deleteTranslationJob.py
+++ b/examples/deleteTranslationJob.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/determineTranslationCost.py
+++ b/examples/determineTranslationCost.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getAccountBalance.py
+++ b/examples/getAccountBalance.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getAccountStats.py
+++ b/examples/getAccountStats.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getServiceLanguageMatrix.py
+++ b/examples/getServiceLanguageMatrix.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getServiceLanguagePairs.py
+++ b/examples/getServiceLanguagePairs.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getServiceLanguages.py
+++ b/examples/getServiceLanguages.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJob.py
+++ b/examples/getTranslationJob.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobBatch.py
+++ b/examples/getTranslationJobBatch.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobComments.py
+++ b/examples/getTranslationJobComments.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobFeedback.py
+++ b/examples/getTranslationJobFeedback.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobRevision.py
+++ b/examples/getTranslationJobRevision.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobRevisions.py
+++ b/examples/getTranslationJobRevisions.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/getTranslationJobs.py
+++ b/examples/getTranslationJobs.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/postTranslationJobComment.py
+++ b/examples/postTranslationJobComment.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/postTranslationJobs.py
+++ b/examples/postTranslationJobs.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/unicode2utf8.py
+++ b/examples/unicode2utf8.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.

--- a/examples/updateTranslationJob.py
+++ b/examples/updateTranslationJob.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 # All code provided from the http://gengo.com site, such as API example code
 # and libraries, is provided under the New BSD license unless otherwise
 # noted. Details are below.


### PR DESCRIPTION
I got this from old scripts.

```
% chmod +x postTranslationJobs.py
% ./postTranslationJobs.py
from: can't read /var/mail/gengo
./postTranslationJobs.py: 39: ./postTranslationJobs.py: Syntax error: "(" unexpected
```
