### PR TITLE
Added raise_for_status function to handle http error status

### DIFF
--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -271,6 +271,7 @@ class Gengo(object):
             # fork here...
             response = self.signAndRequestAPILatest(fn, base, query_params,
                                                     post_data, file_data)
+            response.raise_for_status()
             response.connection.close()
             try:
                 results = response.json()


### PR DESCRIPTION
when I got some http error status code from api, usually cause "json parse error" on bottom line.
so I just want to throw HttpError exception to handle that easily.
