### PR TITLE
[#100906588] add comment attachments support

### DIFF
--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -46,7 +46,7 @@ gengo = Gengo(
 
 # Post a comment with attachments on a specific job; perhaps you have some context for the
 # translator or something of the sort.
-print(gengo.postTranslationJobCommentWithAttachments(
+print(gengo.postTranslationJobComment(
     id=42,
     comment={
         'body': 'I love lamp!',

--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -46,10 +46,13 @@ gengo = Gengo(
 
 # Post a comment with attachments on a specific job; perhaps you have some context for the
 # translator or something of the sort.
-print(gengo.postTranslationJobCommentWithAttachments(id=42, comment={
-    'body': 'I love lamp!',
-},
-attachment=[
-    './testfiles/test_file1.txt',
-    './testfiles/test_file2.txt,
-]))
+print(gengo.postTranslationJobCommentWithAttachments(
+    id=42,
+    comment={
+        'body': 'I love lamp!',
+    },
+    attachment=[
+        './testfiles/test_file1.txt',
+        './testfiles/test_file2.txt',
+    ]
+))

--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# All code provided from the http://gengo.com site, such as API example code
+# and libraries, is provided under the New BSD license unless otherwise
+# noted. Details are below.
+#
+# New BSD License
+# Copyright (c) 2009-2015, Gengo, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of Gengo, Inc. nor the names of its contributors may
+# be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from gengo import Gengo
+
+# Get an instance of Gengo to work with...
+gengo = Gengo(
+    public_key='your_public_key',
+    private_key='your_private_key',
+    sandbox=True,
+    debug=True
+)
+
+# Post a comment with attachments on a specific job; perhaps you have some context for the
+# translator or something of the sort.
+print(gengo.postTranslationJobCommentWithAttachments(id=42, comment={
+    'body': 'I love lamp!',
+},
+attachment=[
+    './testfiles/test_file1.txt',
+    './testfiles/test_file2.txt,
+]))

--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -51,7 +51,7 @@ print(gengo.postTranslationJobCommentWithAttachments(
     comment={
         'body': 'I love lamp!',
     },
-    attachment=[
+    attachments=[
         './testfiles/test_file1.txt',
         './testfiles/test_file2.txt',
     ]

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -212,6 +212,8 @@ class Gengo(object):
                 post_data['action'] = kwargs.pop('action')
             if 'job_ids' in kwargs:
                 post_data['job_ids'] = kwargs.pop('job_ids')
+            if 'attachment' in kwargs:
+                post_data['attachment'] = kwargs.pop('attachment')
 
             # Set up a true base URL, abstracting away the need to care
             # about the sandbox mode or API versioning at this stage.
@@ -267,6 +269,18 @@ class Gengo(object):
                             )
                             j['file_key'] = 'file_' + k
                             del j['file_path']
+
+            # If any attachments then modify base url to include
+            # private_key and file_data to include attachments as multipart
+            if 'attachment' in post_data:
+                base += '?token='+ self.private_key
+                file_data = [
+                    ('json', json.dumps(post_data['comment'])),
+                ]
+
+                attachments = post_data['attachment']
+                for a in attachments:
+                    file_data.append(('document', open(a, 'rb')))
 
             # If any further APIs require their own special signing needs,
             # fork here...

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -273,7 +273,6 @@ class Gengo(object):
             # If any attachments then modify base url to include
             # private_key and file_data to include attachments as multipart
             if 'attachment' in post_data:
-                base += '?token=' + self.private_key
                 file_data = [
                     ('json', json.dumps(post_data['comment'])),
                 ]

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -273,7 +273,7 @@ class Gengo(object):
             # If any attachments then modify base url to include
             # private_key and file_data to include attachments as multipart
             if 'attachment' in post_data:
-                base += '?token='+ self.private_key
+                base += '?token=' + self.private_key
                 file_data = [
                     ('json', json.dumps(post_data['comment'])),
                 ]

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -288,7 +288,7 @@ class Gengo(object):
                 # If any further APIs require their own special signing needs,
                 # fork here...
                 response = self.signAndRequestAPILatest(fn, base, query_params,
-                                                    post_data, file_data)
+                                                        post_data, file_data)
                 response.connection.close()
             finally:
                 for f in files:

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -212,8 +212,8 @@ class Gengo(object):
                 post_data['action'] = kwargs.pop('action')
             if 'job_ids' in kwargs:
                 post_data['job_ids'] = kwargs.pop('job_ids')
-            if 'attachment' in kwargs:
-                post_data['attachment'] = kwargs.pop('attachment')
+            if 'attachments' in kwargs:
+                post_data['attachments'] = kwargs.pop('attachments')
 
             # Set up a true base URL, abstracting away the need to care
             # about the sandbox mode or API versioning at this stage.
@@ -272,12 +272,12 @@ class Gengo(object):
 
             # If any attachments then modify base url to include
             # private_key and file_data to include attachments as multipart
-            if 'attachment' in post_data:
+            if 'attachments' in post_data:
                 file_data = [
                     ('json', json.dumps(post_data['comment'])),
                 ]
 
-                attachments = post_data['attachment']
+                attachments = post_data['attachments']
                 for a in attachments:
                     file_data.append(('document', open(a, 'rb')))
 

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -272,6 +272,7 @@ class Gengo(object):
 
             # If any attachments then modify base url to include
             # private_key and file_data to include attachments as multipart
+            files = []
             if 'attachments' in post_data:
                 file_data = [
                     ('json', json.dumps(post_data['comment'])),
@@ -279,13 +280,20 @@ class Gengo(object):
 
                 attachments = post_data['attachments']
                 for a in attachments:
-                    file_data.append(('document', open(a, 'rb')))
+                    f = open(a, 'rb')
+                    files.append(f)
+                    file_data.append(('document', f))
 
-            # If any further APIs require their own special signing needs,
-            # fork here...
-            response = self.signAndRequestAPILatest(fn, base, query_params,
+            try:
+                # If any further APIs require their own special signing needs,
+                # fork here...
+                response = self.signAndRequestAPILatest(fn, base, query_params,
                                                     post_data, file_data)
-            response.connection.close()
+                response.connection.close()
+            finally:
+                for f in files:
+                    f.close()
+
             try:
                 results = response.json()
             except TypeError:

--- a/gengo/mockdb.py
+++ b/gengo/mockdb.py
@@ -116,6 +116,10 @@ apihash = {
         'url': '/translate/job/{{id}}/comment',
         'method': 'POST',
     },
+    'postTranslationJobCommentWithAttachments': {
+        'url': '/comments/job/{{id}}',
+        'method': 'POST',
+    },
     'getTranslationJobComments': {
         'url': '/translate/job/{{id}}/comments',
         'method': 'GET',

--- a/gengo/mockdb.py
+++ b/gengo/mockdb.py
@@ -116,10 +116,6 @@ apihash = {
         'url': '/translate/job/{{id}}/comment',
         'method': 'POST',
     },
-    'postTranslationJobCommentWithAttachments': {
-        'url': '/comments/job/{{id}}',
-        'method': 'POST',
-    },
     'getTranslationJobComments': {
         'url': '/translate/job/{{id}}/comments',
         'method': 'GET',

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -186,6 +186,44 @@ class TestPostTranslationJobComment(unittest.TestCase):
             mockdb.apihash['postTranslationJobComment']['url']
             .replace('{{id}}', '123'))
 
+class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
+
+    """
+    Tests the flow of creating a job, updating one of them, getting the
+    details, and then deleting the jobs.
+    """
+    def setUp(self):
+        """
+        Creates the initial batch of jobs for the other test functions here
+        to operate on.
+        """
+        self.gengo = Gengo(public_key=API_PUBKEY,
+                           private_key=API_PRIVKEY,
+                           sandbox=True)
+
+        from gengo import requests
+        self.json_mock = mock.Mock()
+        self.json_mock.json.return_value = {'opstat': 'ok'}
+        self.getMock = RequestsMock(return_value=self.json_mock)
+        self.requestsPatch = mock.patch.object(requests, 'post', self.getMock)
+        self.requestsPatch.start()
+
+    def tearDown(self):
+        self.requestsPatch.stop()
+
+    def test_postJobCommentWithAttachments(self):
+        """
+        Tests posting a comment with attachments to a job.
+        """
+        posted_comment = self.gengo.postTranslationJobCommentWithAttachments(
+            id=123,
+            comment={'body': 'I love lamp oh mai gawd'},
+            attachment=['./requirements.txt', './README.md'])
+        self.assertEqual(posted_comment['opstat'], 'ok')
+        self.getMock.assert_path_contains(
+            mockdb.apihash['postTranslationJobCommentWithAttachments']['url']
+            .replace('{{id}}', '123'))
+
 
 class TestTranslationJobFlowFileUpload(unittest.TestCase):
 

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -222,8 +222,8 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
                 'body': 'I love lamp oh mai gawd'
             },
             attachment=[
-                '../examples/testfiles/test_file1.txt',
-                '../examples/testfiles/test_file2.txt'
+                './examples/testfiles/test_file1.txt',
+                './examples/testfiles/test_file2.txt'
             ]
         )
         self.assertEqual(posted_comment['opstat'], 'ok')

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -218,8 +218,14 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
         """
         posted_comment = self.gengo.postTranslationJobCommentWithAttachments(
             id=123,
-            comment={'body': 'I love lamp oh mai gawd'},
-            attachment=['./requirements.txt', './README.md'])
+            comment={
+                'body': 'I love lamp oh mai gawd'
+            },
+            attachment=[
+                '../examples/testfiles/test_file1.txt',
+                '../examples/testfiles/test_file2.txt'
+            ]
+        )
         self.assertEqual(posted_comment['opstat'], 'ok')
         self.getMock.assert_path_contains(
             mockdb.apihash['postTranslationJobCommentWithAttachments']['url']

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -216,19 +216,19 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
         """
         Tests posting a comment with attachments to a job.
         """
-        posted_comment = self.gengo.postTranslationJobCommentWithAttachments(
+        posted_comment = self.gengo.postTranslationJobComment(
             id=123,
             comment={
                 'body': 'I love lamp oh mai gawd'
             },
-            attachment=[
+            attachments=[
                 './examples/testfiles/test_file1.txt',
                 './examples/testfiles/test_file2.txt'
             ]
         )
         self.assertEqual(posted_comment['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['postTranslationJobCommentWithAttachments']['url']
+            mockdb.apihash['postTranslationJobComment']['url']
             .replace('{{id}}', '123'))
 
 

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -186,6 +186,7 @@ class TestPostTranslationJobComment(unittest.TestCase):
             mockdb.apihash['postTranslationJobComment']['url']
             .replace('{{id}}', '123'))
 
+
 class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
 
     """


### PR DESCRIPTION
Update for adding support for comments with attachments.

Originally wanted to add on extra parameter to `postTranslationJobComment` but as we are not making a call to the `customer api` but to `g` so had to split the methods and add `postTranslationJobCommentWithAttachments ` :/ Suggestions are welcome if there is a better way on doing this :bow: 