### PR TITLE
[#100906588] Implementing URL attachments as in the gengo-php clint library

### DIFF
--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -50,7 +50,7 @@ print(gengo.postTranslationJobComment(
     id=42,
     comment={
         'body': 'I love lamp!',
-        'attachments': [
+        'url_attachments': [
             {
                 'url': 'https://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
                 'filename': 'gengo_logo_circle_512.png',

--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -50,9 +50,12 @@ print(gengo.postTranslationJobComment(
     id=42,
     comment={
         'body': 'I love lamp!',
+        'attachments': [
+            {
+                'url': 'https://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
+                'filename': 'gengo_logo_circle_512.png',
+                'mime_type': 'image/png',
+            }
+        ],
     },
-    attachments=[
-        './testfiles/test_file1.txt',
-        './testfiles/test_file2.txt',
-    ]
 ))

--- a/examples/postTranslationJobs.py
+++ b/examples/postTranslationJobs.py
@@ -58,6 +58,13 @@ data = {
 
             'auto_approve': 0,  # OPTIONAL. Hopefully self explanatory (1 = yes, 0 = no),
             'comment': 'HEY THERE TRANSLATOR',  # OPTIONAL. Comment to leave for translator.
+            'url_attachments': [  # OPTIONAL. Comment URL attachments.
+                {
+                    'url': 'https://gengo.github.io/style-guide/assets/images/logos/gengo_logo_circle_512.png',
+                    'filename': 'gengo_logo_circle_512.png',
+                    'mime_type': 'image/png',
+                },
+            ],
             'callback_url': 'http://...',  # OPTIONAL. Callback URL that updates are sent to.
             'custom_data': 'your optional custom data, limited to 1kb.'  # OPTIONAL
         },

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -207,7 +207,8 @@ class Gengo(object):
                 if 'comment' in jobs_dict:
                     post_data['jobs']['comment'] = jobs_dict.pop('comment')
                 if 'url_attachments' in jobs_dict:
-                    post_data['jobs']['url_attachments'] = jobs_dict.pop('url_attachments')
+                    post_data['jobs']['url_attachments'] =\
+                     jobs_dict.pop('url_attachments')
             if 'comment' in kwargs:
                 post_data['comment'] = kwargs.pop('comment')
             if 'action' in kwargs:

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -419,9 +419,9 @@ class Gengo(object):
 
     def replaceURLAttachmentsWithAttachments(self, obj):
         """
-        This method replaces url_attachments with attachments, which is the data
-        structure the comments API wants, as url_attachments is no longer needed
-        we remove it.
+        This method replaces url_attachments with attachments, which is the
+        data structure the comments API wants, as url_attachments is no longer
+        needed we remove it.
 
         obj - job or comment object
         """

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -272,21 +272,21 @@ class Gengo(object):
                             j['file_key'] = 'file_' + k
                             del j['file_path']
 
-            # If any files then modify base url to include
-            # private_key and file_data to include files as multipart
-            tmp_files = []
-            if 'files' in post_data:
-                file_data = [
-                    ('body', post_data['comment']['body']),
-                ]
-
-                files = post_data['files']
-                for a in files:
-                    f = open(a, 'rb')
-                    tmp_files.append(f)
-                    file_data.append(('files', f))
-
             try:
+                # If any files then modify base url to include
+                # private_key and file_data to include files as multipart
+                tmp_files = []
+                if 'files' in post_data:
+                    file_data = [
+                        ('body', post_data['comment']['body']),
+                    ]
+
+                    files = post_data['files']
+                    for a in files:
+                        f = open(a, 'rb')
+                        tmp_files.append(f)
+                        file_data.append(('files', f))
+
                 # If any further APIs require their own special signing needs,
                 # fork here...
                 response = self.signAndRequestAPILatest(fn, base, query_params,

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -276,13 +276,13 @@ class Gengo(object):
             order = post_data.get('jobs', {})
             self.modifyURLAttachments(order)
 
-            # handle jobs url attachments
+            # handle post jobs url attachments
             jobs = post_data.get('jobs', {}).get('jobs', {})
             for j in jobs.items():
                 if isinstance(j, dict):
                     self.modifyURLAttachments(j)
 
-            # handle comment url attachments
+            # handle post comment url attachments
             comments = post_data.get('comment', {})
             self.modifyURLAttachments(comments)
 

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -212,10 +212,8 @@ class Gengo(object):
                 post_data['action'] = kwargs.pop('action')
             if 'job_ids' in kwargs:
                 post_data['job_ids'] = kwargs.pop('job_ids')
-            if 'files' in kwargs:
-                post_data['files'] = kwargs.pop('files')
-            if 'attachments' in kwargs:
-                post_data['attachments'] = kwargs.pop('attachments')
+            if 'file_attachments' in kwargs:
+                post_data['file_attachments'] = kwargs.pop('file_attachments')
 
             # Set up a true base URL, abstracting away the need to care
             # about the sandbox mode or API versioning at this stage.
@@ -273,19 +271,20 @@ class Gengo(object):
                             del j['file_path']
 
             try:
-                # If any files then modify base url to include
-                # private_key and file_data to include files as multipart
+                # If any file_attachments then modify base url to include
+                # private_key and file_data to include file_attachments as multipart
                 tmp_files = []
-                if 'files' in post_data:
+                if 'file_attachments' in post_data:
                     file_data = [
                         ('body', post_data['comment']['body']),
                     ]
 
-                    files = post_data['files']
-                    for a in files:
+                    file_attachments = post_data['file_attachments']
+                    for a in file_attachments:
                         f = open(a, 'rb')
                         tmp_files.append(f)
-                        file_data.append(('files', f))
+                        # file_data.append(('file_attachments', f))
+                        file_data.append(('file_attachments', ('test.png', f, 'image/png')))
 
                 # If any further APIs require their own special signing needs,
                 # fork here...

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -206,6 +206,8 @@ class Gengo(object):
                     post_data['jobs']['as_group'] = jobs_dict.pop('as_group')
                 if 'comment' in jobs_dict:
                     post_data['jobs']['comment'] = jobs_dict.pop('comment')
+                if 'url_attachments' in jobs_dict:
+                    post_data['jobs']['url_attachments'] = jobs_dict.pop('url_attachments')
             if 'comment' in kwargs:
                 post_data['comment'] = kwargs.pop('comment')
             if 'action' in kwargs:
@@ -269,6 +271,20 @@ class Gengo(object):
                             )
                             j['file_key'] = 'file_' + k
                             del j['file_path']
+
+            # handle order url attachments
+            order = post_data.get('jobs', {})
+            self.modifyURLAttachments(order)
+
+            # handle jobs url attachments
+            jobs = post_data.get('jobs', {}).get('jobs', {})
+            for j in jobs.items():
+                if isinstance(j, dict):
+                    self.modifyURLAttachments(j)
+
+            # handle comment url attachments
+            comments = post_data.get('comment', {})
+            self.modifyURLAttachments(comments)
 
             try:
                 # If any file_attachments then modify base url to include
@@ -399,6 +415,19 @@ class Gengo(object):
                               # Don't know why but requests is trying to verify
                               # SSL here ...
                               verify=False)
+
+    def modifyURLAttachments(self, obj):
+        """
+        modifyURLAttachments handles url attachments for a given object
+
+        obj - job or comment object
+        """
+        if 'url_attachments' in obj:
+            obj['attachments'] = []
+            for a in obj['url_attachments']:
+                obj['attachments'].append(a)
+
+            del obj['url_attachments']
 
     @staticmethod
     def compatibletext(text):

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -274,7 +274,7 @@ class Gengo(object):
 
             # If any files then modify base url to include
             # private_key and file_data to include files as multipart
-            tmpFiles = []
+            tmp_files = []
             if 'files' in post_data:
                 file_data = [
                     ('body', post_data['comment']['body']),
@@ -283,7 +283,7 @@ class Gengo(object):
                 files = post_data['files']
                 for a in files:
                     f = open(a, 'rb')
-                    tmpFiles.append(f)
+                    tmp_files.append(f)
                     file_data.append(('files', f))
 
             try:
@@ -293,7 +293,7 @@ class Gengo(object):
                                                         post_data, file_data)
                 response.connection.close()
             finally:
-                for f in tmpFiles:
+                for f in tmp_files:
                     f.close()
 
             try:

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -275,17 +275,17 @@ class Gengo(object):
 
             # handle order url attachments
             order = post_data.get('jobs', {})
-            self.modifyURLAttachments(order)
+            self.replaceURLAttachmentsWithAttachments(order)
 
             # handle post jobs url attachments
             jobs = post_data.get('jobs', {}).get('jobs', {})
             for k, j in jobs.items():
                 if isinstance(j, dict):
-                    self.modifyURLAttachments(j)
+                    self.replaceURLAttachmentsWithAttachments(j)
 
             # handle post comment url attachments
             comments = post_data.get('comment', {})
-            self.modifyURLAttachments(comments)
+            self.replaceURLAttachmentsWithAttachments(comments)
 
             try:
                 # If any file_attachments then modify base url to include
@@ -417,9 +417,11 @@ class Gengo(object):
                               # SSL here ...
                               verify=False)
 
-    def modifyURLAttachments(self, obj):
+    def replaceURLAttachmentsWithAttachments(self, obj):
         """
-        modifyURLAttachments handles url attachments for a given object
+        This method replaces url_attachments with attachments, which is the data
+        structure the comments API wants, as url_attachments is no longer needed
+        we remove it.
 
         obj - job or comment object
         """
@@ -427,10 +429,7 @@ class Gengo(object):
             if not isinstance(obj['url_attachments'], list):
                 raise GengoError("Job url attachment MUST be an list", 1)
 
-            obj['attachments'] = []
-            for a in obj['url_attachments']:
-                obj['attachments'].append(a)
-
+            obj['attachments'] = obj['url_attachments']
             del obj['url_attachments']
 
     @staticmethod

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -425,7 +425,7 @@ class Gengo(object):
         """
         if 'url_attachments' in obj:
             if not isinstance(obj['url_attachments'], list):
-                raise GengoError("Job url attachment MUST be an array", 1)
+                raise GengoError("Job url attachment MUST be an list", 1)
 
             obj['attachments'] = []
             for a in obj['url_attachments']:

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -278,7 +278,7 @@ class Gengo(object):
 
             # handle post jobs url attachments
             jobs = post_data.get('jobs', {}).get('jobs', {})
-            for j in jobs.items():
+            for k, j in jobs.items():
                 if isinstance(j, dict):
                     self.modifyURLAttachments(j)
 
@@ -423,6 +423,9 @@ class Gengo(object):
         obj - job or comment object
         """
         if 'url_attachments' in obj:
+            if not isinstance(obj['url_attachments'], list):
+                raise GengoError("Job url attachment MUST be an array", 1)
+
             obj['attachments'] = []
             for a in obj['url_attachments']:
                 obj['attachments'].append(a)

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -272,7 +272,8 @@ class Gengo(object):
 
             try:
                 # If any file_attachments then modify base url to include
-                # private_key and file_data to include file_attachments as multipart
+                # private_key and file_data to include file_attachments as
+                # multipart.
                 tmp_files = []
                 if 'file_attachments' in post_data:
                     file_data = [

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -283,8 +283,7 @@ class Gengo(object):
                     for a in file_attachments:
                         f = open(a, 'rb')
                         tmp_files.append(f)
-                        # file_data.append(('file_attachments', f))
-                        file_data.append(('file_attachments', ('test.png', f, 'image/png')))
+                        file_data.append(('file_attachments', f))
 
                 # If any further APIs require their own special signing needs,
                 # fork here...

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -212,6 +212,8 @@ class Gengo(object):
                 post_data['action'] = kwargs.pop('action')
             if 'job_ids' in kwargs:
                 post_data['job_ids'] = kwargs.pop('job_ids')
+            if 'files' in kwargs:
+                post_data['files'] = kwargs.pop('files')
             if 'attachments' in kwargs:
                 post_data['attachments'] = kwargs.pop('attachments')
 
@@ -270,19 +272,19 @@ class Gengo(object):
                             j['file_key'] = 'file_' + k
                             del j['file_path']
 
-            # If any attachments then modify base url to include
-            # private_key and file_data to include attachments as multipart
-            files = []
-            if 'attachments' in post_data:
+            # If any files then modify base url to include
+            # private_key and file_data to include files as multipart
+            tmpFiles = []
+            if 'files' in post_data:
                 file_data = [
-                    ('json', json.dumps(post_data['comment'])),
+                    ('body', post_data['comment']['body']),
                 ]
 
-                attachments = post_data['attachments']
-                for a in attachments:
+                files = post_data['files']
+                for a in files:
                     f = open(a, 'rb')
-                    files.append(f)
-                    file_data.append(('document', f))
+                    tmpFiles.append(f)
+                    file_data.append(('files', f))
 
             try:
                 # If any further APIs require their own special signing needs,
@@ -291,7 +293,7 @@ class Gengo(object):
                                                         post_data, file_data)
                 response.connection.close()
             finally:
-                for f in files:
+                for f in tmpFiles:
                     f.close()
 
             try:

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -221,7 +221,7 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
             comment={
                 'body': 'I love lamp oh mai gawd'
             },
-            attachments=[
+            files=[
                 './examples/testfiles/test_file1.txt',
                 './examples/testfiles/test_file2.txt'
             ]

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -221,7 +221,7 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
             comment={
                 'body': 'I love lamp oh mai gawd'
             },
-            files=[
+            file_attachments=[
                 './examples/testfiles/test_file1.txt',
                 './examples/testfiles/test_file2.txt'
             ]


### PR DESCRIPTION
Implementing `url_attachments` for handling URL based attachments for order and jobs comments.
Reflecting gengo-php clint library changes: https://github.com/gengo/gengo-php/pull/35