### PR TITLE
use absolute imports even when importing relative paths

### DIFF
--- a/examples/deleteTranslationJob.py
+++ b/examples/deleteTranslationJob.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/determineTranslationCost.py
+++ b/examples/determineTranslationCost.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getAccountBalance.py
+++ b/examples/getAccountBalance.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getAccountStats.py
+++ b/examples/getAccountStats.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getOrderComments.py
+++ b/examples/getOrderComments.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getServiceLanguageMatrix.py
+++ b/examples/getServiceLanguageMatrix.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getServiceLanguagePairs.py
+++ b/examples/getServiceLanguagePairs.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getServiceLanguages.py
+++ b/examples/getServiceLanguages.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 from pprint import pprint
 

--- a/examples/getTranslationJob.py
+++ b/examples/getTranslationJob.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobBatch.py
+++ b/examples/getTranslationJobBatch.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobComments.py
+++ b/examples/getTranslationJobComments.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobFeedback.py
+++ b/examples/getTranslationJobFeedback.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobRevision.py
+++ b/examples/getTranslationJobRevision.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobRevisions.py
+++ b/examples/getTranslationJobRevisions.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/getTranslationJobs.py
+++ b/examples/getTranslationJobs.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/postOrderComment.py
+++ b/examples/postOrderComment.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/postTranslationJobComment.py
+++ b/examples/postTranslationJobComment.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/postTranslationJobCommentWithAttachments.py
+++ b/examples/postTranslationJobCommentWithAttachments.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/postTranslationJobs.py
+++ b/examples/postTranslationJobs.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/unicode2utf8.py
+++ b/examples/unicode2utf8.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # This method doesn't require an instance of Gengo, it's

--- a/examples/updateTranslationJob.py
+++ b/examples/updateTranslationJob.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/examples/updateTranslationJobs.py
+++ b/examples/updateTranslationJobs.py
@@ -34,6 +34,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from gengo import Gengo
 
 # Get an instance of Gengo to work with...

--- a/gengo/__init__.py
+++ b/gengo/__init__.py
@@ -31,6 +31,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from gengo import Gengo, GengoError, GengoAuthError
+from __future__ import absolute_import
+
+from .gengo import Gengo, GengoError, GengoAuthError
 
 __all__ = ['Gengo', 'GengoError', 'GengoAuthError']

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -33,9 +33,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # mockdb is a file with a dictionary of every API endpoint for Gengo.
-from __future__ import print_function
-from mockdb import api_urls, apihash
-from _version import __version__
+from __future__ import absolute_import, print_function
+from .mockdb import api_urls, apihash
+from ._version import __version__
 
 import re
 import copy

--- a/gengo/tests.py
+++ b/gengo/tests.py
@@ -36,13 +36,15 @@
 A set of tests for the Gengo API. They all require an internet connection.
 """
 
+from __future__ import absolute_import
+
 import unittest
 try:
     import mock
 except ImportError:
     import unittest.mock as mock
 
-import mockdb
+from gengo import mockdb
 from gengo import Gengo, GengoError, GengoAuthError
 
 API_PUBKEY = 'dummypublickey'
@@ -86,7 +88,7 @@ class TestAccountMethods(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -120,7 +122,7 @@ class TestLanguageServiceMethods(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -164,7 +166,7 @@ class TestPostTranslationJobComment(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -202,7 +204,7 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -247,7 +249,7 @@ class TestTranslationJobFlowFileUpload(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -325,7 +327,7 @@ class TestTranslationJobFlowGroupJob(unittest.TestCase):
                            sandbox=True)
         self.created_job_ids = []
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -364,7 +366,7 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -445,7 +447,7 @@ class TestGlossaryFunctions(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -487,7 +489,7 @@ class TestPreferredTranslatorsFunction(unittest.TestCase):
                            sandbox=True,
                            )
 
-        from gengo import requests
+        from .gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)


### PR DESCRIPTION
This PR is an attempt to use `absolute_import` so that the Gengo Python client is both python 2 and 3 compatible in terms of importing packages and etc.