### PR TITLE
[#110709054] add example on get translation order

### DIFF
--- a/examples/getTranslationOrderJobs.py
+++ b/examples/getTranslationOrderJobs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# All code provided from the http://gengo.com site, such as API example code
+# and libraries, is provided under the New BSD license unless otherwise
+# noted. Details are below.
+#
+# New BSD License
+# Copyright (c) 2009-2015, Gengo, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of Gengo, Inc. nor the names of its contributors may
+# be used to endorse or promote products derived from this software
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from gengo import Gengo
+
+# Get an instance of Gengo to work with...
+gengo = Gengo(
+    public_key='your_public_key',
+    private_key='your_private_key',
+    sandbox=False,
+    debug=True
+)
+
+# Retrieve job statuses on a specific order
+print gengo.getTranslationOrderJobs(id="124")

--- a/examples/getTranslationOrderJobs.py
+++ b/examples/getTranslationOrderJobs.py
@@ -45,4 +45,4 @@ gengo = Gengo(
 )
 
 # Retrieve job statuses on a specific order
-print gengo.getTranslationOrderJobs(id="124")
+print(gengo.getTranslationOrderJobs(id=124))


### PR DESCRIPTION
This PR updates the Gengo Python client library such that we provide an example of how an API user may retrieve job statuses (ie., jobs queued, jobs available, jobs incomplete).

Example viewable on the API documentation @ http://developers.gengo.com/v2/api_methods/order/#order-get