### PR TITLE
Remove `pre_mt` parameter from example script

### DIFF
--- a/examples/getTranslationJob.py
+++ b/examples/getTranslationJob.py
@@ -44,6 +44,4 @@ gengo = Gengo(
     debug=True
 )
 
-# Get the job in question; pre_mt set to 1 will give you a machine translation
-# if the human translation isn't available yet. ;)
-print(gengo.getTranslationJob(id=42, pre_mt=1))
+print(gengo.getTranslationJob(id=42))


### PR DESCRIPTION
Because API doesn't support this parameter anymore.