### PR TITLE
Fix for issue #67

### DIFF
--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -445,7 +445,7 @@ class Gengo(object):
         # the value as is if it's already a bytes object.
         if isinstance(text, bytes):
             return text
-        
+
         return bytes(text, 'utf-8')
 
     @staticmethod

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -435,15 +435,17 @@ class Gengo(object):
     @staticmethod
     def compatibletext(text):
         if sys.version_info < (3, 0, 0):
-            if isinstance(text, bytes):
-                return text
-            else:
-                # Converting to string if the "text" value data type is
-                # anything other than "str" such as unicode, int etc.
-                # Doing this because hmac.new function only takes "bytes"
-                # or "str" depending on Python version 3.x or 2.x
-                return str(text)
+            # Converting to string if the "text" value data type is
+            # anything other than "str" such as unicode, int etc.
+            # Doing this because hmac.new function only takes "str"
+            # for Python version 2.x
+            return str(text)
 
+        # Converting to "bytes" again will throw TypeError, so returning
+        # the value as is if it's already a bytes object.
+        if isinstance(text, bytes):
+            return text
+        
         return bytes(text, 'utf-8')
 
     @staticmethod

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -381,7 +381,7 @@ class Gengo(object):
                 query_params['data'] = json.dumps(post_data['action'],
                                                   separators=(',', ':'))
 
-            query_hmac = hmac.new(Gengo.compatibletext(self.private_key),
+            query_hmac = hmac.new(self.private_key,
                                   Gengo.compatibletext(query_params['ts']),
                                   sha1)
             query_params['api_sig'] = query_hmac.hexdigest()
@@ -402,7 +402,7 @@ class Gengo(object):
             query_string = urlencode(sorted(query_params.items(),
                                             key=itemgetter(0)))
             if self.private_key is not None:
-                query_hmac = hmac.new(Gengo.compatibletext(self.private_key),
+                query_hmac = hmac.new(self.private_key,
                                       Gengo.compatibletext(query_params['ts']),
                                       sha1)
                 query_params['api_sig'] = query_hmac.hexdigest()
@@ -434,8 +434,15 @@ class Gengo(object):
 
     @staticmethod
     def compatibletext(text):
-        if sys.version_info < (3, 0, 0) or isinstance(text, bytes):
-            return str(text)
+        if sys.version_info < (3, 0, 0): 
+            if isinstance(text, bytes):
+                return text
+            else:
+                # Converting to string if the "text" value data type is 
+                # anything other than "str" such as unicode, int etc.
+                # Doing this because hmac.new function only takes "bytes"
+                # or "str" depending on Python version 3.x or 2.x
+                return str(text)
 
         return bytes(text, 'utf-8')
 

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -381,7 +381,7 @@ class Gengo(object):
                 query_params['data'] = json.dumps(post_data['action'],
                                                   separators=(',', ':'))
 
-            query_hmac = hmac.new(self.private_key,
+            query_hmac = hmac.new(Gengo.compatibletext(self.private_key),
                                   Gengo.compatibletext(query_params['ts']),
                                   sha1)
             query_params['api_sig'] = query_hmac.hexdigest()
@@ -402,7 +402,7 @@ class Gengo(object):
             query_string = urlencode(sorted(query_params.items(),
                                             key=itemgetter(0)))
             if self.private_key is not None:
-                query_hmac = hmac.new(self.private_key,
+                query_hmac = hmac.new(Gengo.compatibletext(self.private_key),
                                       Gengo.compatibletext(query_params['ts']),
                                       sha1)
                 query_params['api_sig'] = query_hmac.hexdigest()
@@ -435,7 +435,7 @@ class Gengo(object):
     @staticmethod
     def compatibletext(text):
         if sys.version_info < (3, 0, 0) or isinstance(text, bytes):
-            return text
+            return str(text)
 
         return bytes(text, 'utf-8')
 

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -434,11 +434,11 @@ class Gengo(object):
 
     @staticmethod
     def compatibletext(text):
-        if sys.version_info < (3, 0, 0): 
+        if sys.version_info < (3, 0, 0):
             if isinstance(text, bytes):
                 return text
             else:
-                # Converting to string if the "text" value data type is 
+                # Converting to string if the "text" value data type is
                 # anything other than "str" such as unicode, int etc.
                 # Doing this because hmac.new function only takes "bytes"
                 # or "str" depending on Python version 3.x or 2.x


### PR DESCRIPTION
HMAC function in Python 2.x don't take bytes or Unicode so converting it to normal string using the built-in function 'str'."
