### PR TITLE
Don't require specific version of requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     include_package_data=True,
 
     # Package dependencies.
-    install_requires=["requests == 2.2.1"],
+    install_requires=["requests >= 2.2.1"],
 
     # Metadata for PyPI.
     author='Gengo',


### PR DESCRIPTION
I am assuming that this version of requests is just
a minimum requirement. So it would be nice if that
is the way it behaved. (My project uses a newer version
and this was interfering with it)