### PR TITLE
pep8 to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ python:
 install:
 - pip install -r requirements.txt
 
-# command to run pep8
-before_script: python setup.py pep8
+before_script: flake8 gengo
 # command to run tests
 script: python setup.py test
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Only important changes are mentioned below. See `commit log <https://github.com/
 
 Unreleased
 ----------
-* [Removed] Drop explicit support for Pythons 2.6
+* [Removed] Drop explicit support for Python 2.6
 
 v0.1.30 (2016-10-13)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@ Changelog
 
 Only important changes are mentioned below. See `commit log <https://github.com/gengo/gengo-python/commits/master>`_ and `closed issues <https://github.com/gengo/gengo-python/issues?state=closed>`_ for full changes.
 
+Unreleased
+----------
+* [Removed] Drop explicit support for Pythons 2.6
+
 v0.1.30 (2016-10-13)
 -------------------
 * [Feature] `#76 <https://github.com/gengo/gengo-python/pull/76>`_ Don't require specific version of requests

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Gengo has a full suite of unit tests. To run them, make sure you have the `mock`
 
 ::
 
-   python setup.py test
+   flake8 gengo
 
 If you wish to run a single test, such as TestTranslationJobFlowFileUpload:
 

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -445,7 +445,8 @@ class Gengo(object):
     @staticmethod
     def unicode2utf8(text):
         try:
-            if isinstance(text, unicode):
+            # NOQA because "unicode" is undefined in Python3
+            if isinstance(text, unicode):  # NOQA
                 text = text.encode('utf-8')
         except:
             pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.2.1
-pep8
+flake8
 mock
+requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',

--- a/setup.py
+++ b/setup.py
@@ -48,30 +48,6 @@ exec(open('gengo/_version.py').read())
 # https://github.com/apache/libcloud/blob/trunk/setup.py
 
 
-class Pep8Command(Command):
-    description = "Run pep8 script"
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        try:
-            import pep8
-            pep8
-        except ImportError:
-            print ('Missing "pep8" library. You can install it using pip: '
-                   'pip install pep8')
-            sys.exit(1)
-
-        cwd = os.getcwd()
-        retcode = call(('pep8 {0}/gengo/'.format(cwd)).split(' '))
-        sys.exit(retcode)
-
-
 class TestCommand(Command):
     user_options = []
 
@@ -108,7 +84,6 @@ setup(
     description='Official Python library for interfacing with the Gengo API.',
     long_description=open('README.rst').read(),
     cmdclass={
-        'pep8': Pep8Command,
         'test': TestCommand,
     },
     classifiers=[


### PR DESCRIPTION
With flake8, we can check syntax and style.

This pull request include stop supporting Python 2.6. However we don't have a policy for stop supporting older version. I think we need to have it.
My opinion is the same timing with EOL of the language version.
Also, we should announce it before releasing. (It means we cannot marge this pull request for a while)

EOL Python 2.6 https://mail.python.org/pipermail/python-dev/2013-September/128287.html
Fkake8 is no longer support Python2.6. http://flake8.pycqa.org/en/latest/release-notes/3.0.0.html