### PR TITLE
Python has json package always

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,12 +28,6 @@ And then installing the library:
 
    python setup.py install
 
-This will also install the `requests` package. If you're running on a version of Python prior to 2.6, you'll need to install simplejson as well:
-
-::
-
-   pip install simplejson
-
 
 Tests - Running Them, etc
 -------------------------

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -50,27 +50,7 @@ except ImportError:
     from urllib.parse import urlencode, quote
 from time import time
 from operator import itemgetter
-
-# There are some special setups (like a Django application) where
-# simplejson exists. Past Python 2.6, this should never
-# cause any problems.
-try:
-    # Python 2.6 and up
-    import json
-except ImportError:
-    try:
-        # Python 2.6 and below (2.4/2.5, 2.3 is not guaranteed to work with
-        # this library to begin with)
-        import simplejson as json
-    except ImportError:
-        try:
-            # This case gets rarer by the day, but if we need to, we can
-            # pull it from Django provided it's there.
-            from django.utils import simplejson as json
-        except:
-            raise Exception("gengo requires the simplejson library (or " +
-                            "Python 2.6+) to work. " +
-                            "http://www.undefined.org/python/")
+import json
 
 
 """


### PR DESCRIPTION
Python has json package from Python 2.6. This library is supporting Python 2.7 and later.
It means we can expect Python always has json package.