### PR TITLE
Do not implicit relative import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 
 before_script: flake8 gengo
 # command to run tests
-script: python setup.py test
+script: nosetests --rednose
 
 notifications:
   irc: "irc.freenode.net#Gengo"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Only important changes are mentioned below. See `commit log <https://github.com/
 Unreleased
 ----------
 * [Removed] Drop explicit support for Python 2.6
+* [Fix] Fix implicit relative importing
 
 v0.1.30 (2016-10-13)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Unreleased
 ----------
 * [Removed] Drop explicit support for Python 2.6
 * [Fix] Fix implicit relative importing
+* [Fix] Exclude test file from main package
+* [Feature] Run UnitTest with nose
 
 v0.1.30 (2016-10-13)
 -------------------

--- a/gengo/__init__.py
+++ b/gengo/__init__.py
@@ -31,6 +31,6 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from gengo import Gengo, GengoError, GengoAuthError
+from .gengo import Gengo, GengoError, GengoAuthError
 
 __all__ = ['Gengo', 'GengoError', 'GengoAuthError']

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -34,8 +34,8 @@
 
 # mockdb is a file with a dictionary of every API endpoint for Gengo.
 from __future__ import print_function
-from mockdb import api_urls, apihash
-from _version import __version__
+from .mockdb import api_urls, apihash
+from ._version import __version__
 
 import re
 import copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flake8
 mock
+nose
+rednose
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -33,35 +33,11 @@
 #
 # Original Author: Ryan McGrath <http://venodesigns.net>
 
-import sys
-import os
-from distutils.core import Command
-from setuptools import setup
-from setuptools import find_packages
-from subprocess import call
+from setuptools import setup, find_packages
 
 # little tricky, but this is for version number is in one place.
 __version__ = 'This value will be overridden by exec.'
 exec(open('gengo/_version.py').read())
-
-# Command based on Libcloud setup.py:
-# https://github.com/apache/libcloud/blob/trunk/setup.py
-
-
-class TestCommand(Command):
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import sys
-        import subprocess
-        errno = subprocess.call([sys.executable, 'gengo/tests.py'])
-        raise SystemExit(errno)
 
 setup(
     # Basic package information.
@@ -83,9 +59,6 @@ setup(
     keywords='gengo translation language api',
     description='Official Python library for interfacing with the Gengo API.',
     long_description=open('README.rst').read(),
-    cmdclass={
-        'test': TestCommand,
-    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,7 +42,9 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-import mockdb
+import requests
+
+import gengo.mockdb
 from gengo import Gengo, GengoError, GengoAuthError
 
 API_PUBKEY = 'dummypublickey'
@@ -86,7 +88,6 @@ class TestAccountMethods(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -100,13 +101,13 @@ class TestAccountMethods(unittest.TestCase):
         stats = self.gengo.getAccountStats()
         self.assertEqual(stats['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getAccountStats']['url'])
+            gengo.mockdb.apihash['getAccountStats']['url'])
 
     def test_getAccountBalance(self):
         balance = self.gengo.getAccountBalance()
         self.assertEqual(balance['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getAccountBalance']['url'])
+            gengo.mockdb.apihash['getAccountBalance']['url'])
 
 
 class TestLanguageServiceMethods(unittest.TestCase):
@@ -120,7 +121,6 @@ class TestLanguageServiceMethods(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -134,19 +134,19 @@ class TestLanguageServiceMethods(unittest.TestCase):
         resp = self.gengo.getServiceLanguagePairs()
         self.assertEqual(resp['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getServiceLanguagePairs']['url'])
+            gengo.mockdb.apihash['getServiceLanguagePairs']['url'])
 
     def test_getServiceLanguages(self):
         resp = self.gengo.getServiceLanguages()
         self.assertEqual(resp['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getServiceLanguages']['url'])
+            gengo.mockdb.apihash['getServiceLanguages']['url'])
 
     def test_getServiceLanguageMatrix(self):
         resp = self.gengo.getServiceLanguageMatrix()
         self.assertEqual(resp['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getServiceLanguageMatrix']['url'])
+            gengo.mockdb.apihash['getServiceLanguageMatrix']['url'])
 
 
 class TestPostTranslationJobComment(unittest.TestCase):
@@ -164,7 +164,6 @@ class TestPostTranslationJobComment(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -183,7 +182,7 @@ class TestPostTranslationJobComment(unittest.TestCase):
             comment={'body': 'I love lamp oh mai gawd'})
         self.assertEqual(posted_comment['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['postTranslationJobComment']['url']
+            gengo.mockdb.apihash['postTranslationJobComment']['url']
             .replace('{{id}}', '123'))
 
 
@@ -202,7 +201,6 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -228,7 +226,7 @@ class TestPostTranslationJobCommentWithAttachments(unittest.TestCase):
         )
         self.assertEqual(posted_comment['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['postTranslationJobComment']['url']
+            gengo.mockdb.apihash['postTranslationJobComment']['url']
             .replace('{{id}}', '123'))
 
 
@@ -247,7 +245,6 @@ class TestTranslationJobFlowFileUpload(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -272,20 +269,20 @@ class TestTranslationJobFlowFileUpload(unittest.TestCase):
         job = self.gengo.getTranslationJob(id=123)
         self.assertEqual(job['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJob']['url']
+            gengo.mockdb.apihash['getTranslationJob']['url']
             .replace('{{id}}', '123'))
 
         # Pull down the 10 most recently submitted jobs.
         jobs = self.gengo.getTranslationJobs()
         self.assertEqual(jobs['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobs']['url'])
+            gengo.mockdb.apihash['getTranslationJobs']['url'])
 
         # Test getting the batch that a job is in.
         job_batch = self.gengo.getTranslationJobBatch(id=123)
         self.assertEqual(job_batch['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobBatch']['url']
+            gengo.mockdb.apihash['getTranslationJobBatch']['url']
             .replace('{{id}}', '123'))
 
         # Pull down feedback. This should work fine, but there'll be no
@@ -293,7 +290,7 @@ class TestTranslationJobFlowFileUpload(unittest.TestCase):
         feedback = self.gengo.getTranslationJobFeedback(id=123)
         self.assertEqual(feedback['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobFeedback']['url']
+            gengo.mockdb.apihash['getTranslationJobFeedback']['url']
             .replace('{{id}}', '123'))
 
         # Lastly, pull down any revisions that definitely didn't occur due
@@ -301,7 +298,7 @@ class TestTranslationJobFlowFileUpload(unittest.TestCase):
         revisions = self.gengo.getTranslationJobRevisions(id=123)
         self.assertEqual(revisions['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobRevisions']['url']
+            gengo.mockdb.apihash['getTranslationJobRevisions']['url']
             .replace('{{id}}', '123'))
 
 
@@ -325,7 +322,7 @@ class TestTranslationJobFlowGroupJob(unittest.TestCase):
                            sandbox=True)
         self.created_job_ids = []
 
-        from gengo import requests
+        
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -343,7 +340,7 @@ class TestTranslationJobFlowGroupJob(unittest.TestCase):
         resp = self.gengo.getTranslationOrderJobs(id=321)
         self.assertEqual(resp['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationOrderJobs']['url']
+            gengo.mockdb.apihash['getTranslationOrderJobs']['url']
             .replace('{{id}}', '321'))
 
 
@@ -364,7 +361,7 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
+        import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -381,7 +378,7 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
         job_comments = self.gengo.getTranslationJobComments(id=1)
         self.assertEqual(job_comments['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobComments']['url']
+            gengo.mockdb.apihash['getTranslationJobComments']['url']
             .replace('{{id}}', '1'))
 
     def test_getJobDataMethods(self):
@@ -399,20 +396,20 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
         job = self.gengo.getTranslationJob(id=1)
         self.assertEqual(job['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJob']['url']
+            gengo.mockdb.apihash['getTranslationJob']['url']
             .replace('{{id}}', '1'))
 
         # Pull down the 10 most recently submitted jobs.
         jobs = self.gengo.getTranslationJobs()
         self.assertEqual(jobs['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobs']['url'])
+            gengo.mockdb.apihash['getTranslationJobs']['url'])
 
         # Test getting the batch that a job is in...
         job_batch = self.gengo.getTranslationJobBatch(id=1)
         self.assertEqual(job_batch['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobBatch']['url']
+            gengo.mockdb.apihash['getTranslationJobBatch']['url']
             .replace('{{id}}', '1'))
 
         # Pull down feedback. This should work fine, but there'll be no
@@ -420,7 +417,7 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
         feedback = self.gengo.getTranslationJobFeedback(id=1)
         self.assertEqual(feedback['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobFeedback']['url']
+            gengo.mockdb.apihash['getTranslationJobFeedback']['url']
             .replace('{{id}}', '1'))
 
         # Lastly, pull down any revisions that definitely didn't occur due
@@ -428,7 +425,7 @@ class TestTranslationJobFlowMixedOrder(unittest.TestCase):
         revisions = self.gengo.getTranslationJobRevisions(id=1)
         self.assertEqual(revisions['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getTranslationJobRevisions']['url']
+            gengo.mockdb.apihash['getTranslationJobRevisions']['url']
             .replace('{{id}}', '1'))
 
 
@@ -445,7 +442,6 @@ class TestGlossaryFunctions(unittest.TestCase):
                            private_key=API_PRIVKEY,
                            sandbox=True)
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -459,7 +455,7 @@ class TestGlossaryFunctions(unittest.TestCase):
         resp = self.gengo.getGlossaryList()
         self.assertEqual(resp['opstat'], 'ok')
         self.getMock.assert_path_contains(
-            mockdb.apihash['getGlossaryList']['url'])
+            gengo.mockdb.apihash['getGlossaryList']['url'])
 
 
 class RequestsMock(mock.Mock):
@@ -487,7 +483,6 @@ class TestPreferredTranslatorsFunction(unittest.TestCase):
                            sandbox=True,
                            )
 
-        from gengo import requests
         self.json_mock = mock.Mock()
         self.json_mock.json.return_value = {'opstat': 'ok'}
         self.getMock = RequestsMock(return_value=self.json_mock)
@@ -502,7 +497,7 @@ class TestPreferredTranslatorsFunction(unittest.TestCase):
         self.assertEqual(resp['opstat'], 'ok')
         # self.getMock.assert_any_call()
         self.getMock.assert_path_contains(
-            mockdb.apihash['getPreferredTranslators']['url'])
+            gengo.mockdb.apihash['getPreferredTranslators']['url'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Weekly cleanup

Implicit relative importing does not work with Python 3.
This is the reason why gengo-python cannot install via pip for Python 3.

I combined my another pull request, because it is inconvenient that test file is in main package for this change. But I removed coverage, because it does not work with Python 3.2.
https://github.com/gengo/gengo-python/pull/81

Now it works with Python 3.
```
% python
Python 3.5.1+ (default, Mar 30 2016, 22:46:26) 
[GCC 5.3.1 20160330] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gengo
>>> gengo.Gengo('public', 'private')                                                                                                                                                                                                                                                       
<gengo.gengo.Gengo object at 0x7fa25a608fd0>
```

And Python 2.
```
% python
Python 2.7.12 (default, Jul  1 2016, 15:12:24) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import gengo
>>> gengo.Gengo('public', 'private')
<gengo.gengo.Gengo object at 0x7feb24d7e9d0>
```

Before changes:
```
% python
Python 3.5.1+ (default, Mar 30 2016, 22:46:26) 
[GCC 5.3.1 20160330] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gengo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/motoki/workspace/gengo-python/gengo/__init__.py", line 34, in <module>
    from gengo import Gengo, GengoError, GengoAuthError
ImportError: cannot import name 'Gengo'
```