### PR TITLE
HMAC function in Python 2.x don't take bytes or Unicode so converting…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased
 * [Fix] Fix implicit relative importing
 * [Fix] Exclude test file from main package
 * [Feature] Run UnitTest with nose
+* [Fix] Fix compatibletext issue for Python 2.x
 
 v0.1.30 (2016-10-13)
 -------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Contributors
 
 Thanks to the following contributors (in alphabetical order):
 
+ * Ajay Kumar
  * Alexandre Kirillov
  * Andrea Belvedere
  * Corey Farwell

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -420,7 +420,16 @@ class Gengo(object):
 
     @staticmethod
     def compatibletext(text):
-        if sys.version_info < (3, 0, 0) or isinstance(text, bytes):
+        if sys.version_info < (3, 0, 0):
+            # Converting to string if the "text" value data type is
+            # anything other than "str" such as unicode, int etc.
+            # Doing this because hmac.new function only takes "str"
+            # for Python version 2.x
+            return str(text)
+
+        # Converting to "bytes" again will throw TypeError, so returning
+        # the value as is if it's already a bytes object.
+        if isinstance(text, bytes):
             return text
 
         return bytes(text, 'utf-8')


### PR DESCRIPTION
… it to normal string using the built-in function 'str'."