### PR TITLE
Compatible error handling for Python 2 and 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 
 Only important changes are mentioned below. See `commit log <https://github.com/gengo/gengo-python/commits/master>`_ and `closed issues <https://github.com/gengo/gengo-python/issues?state=closed>`_ for full changes.
 
+Unreleased
+----------
+* [Fix] Improve compatibility for Python 3 in error handling part
+
+
 v0.1.31 (2016-12-07)
 --------------------
 * [Feature] `#83 <https://github.com/gengo/gengo-python/pull/83>`_ Add support for reference_id (stealth undocumented feature)

--- a/gengo/gengo.py
+++ b/gengo/gengo.py
@@ -412,9 +412,8 @@ class Gengo(object):
                     message_code['code'], message_code['msg']
                 )
 
-        concatted_msg = ' '.join(messages)
         error_code = error_codes[0] if error_codes else None
-        raise GengoError(concatted_msg, error_code)
+        raise GengoError(' '.join(messages), error_code)
 
     def _raiseForSingleErrorResponse(self, results):
         raise GengoError(results['err']['msg'], results['err']['code'])


### PR DESCRIPTION
Weekly cleanup. Maybe this is not cleanup but...

Originally, error handling part was using deprecated methods which
dict.iteritems and dict.itervalues. They are already removed in Python 3.
So that part does not work with Python 3.

I removed that deprecated methods. And split error handling part from big
method. It would help next developping. Already it helped me for writing
unittest.

Also I added logging. Gengo API might return multiple errors one time. However
GengoError class accept only one error message and code. So it ignores the
second and any later errors. Logger will catch them when debug is enabled.
```
2016-12-10 14:37:43,525 ERROR [gengo.gengo:417][MainThread] Gengo returned an error, code: 1350, message: "body_src" is a required field
2016-12-10 14:37:43,525 ERROR [gengo.gengo:417][MainThread] Gengo returned an error, code: 1400, message: "lc_src" is a required field
2016-12-10 14:37:43,526 ERROR [gengo.gengo:417][MainThread] Gengo returned an error, code: 1450, message: "lc_tgt" is a required field
2016-12-10 14:37:43,526 ERROR [gengo.gengo:417][MainThread] Gengo returned an error, code: 1500, message: "tier" is a required field
```