### PR TITLE
Support newer version Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 # command to install dependencies
 install:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Only important changes are mentioned below. See `commit log <https://github.com/
 Unreleased
 ----------
 * [Fix] Improve compatibility for Python 3 in error handling part
+* [Feature] Official support Python 3.5 and 3.6
 
 
 v0.1.31 (2016-12-07)

--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )


### PR DESCRIPTION
Recentlly, Python 3.6 was released. Let's support it!
And we didn't support 3.5, but I think this is opportunity, Let's support it too.