### PR TITLE
Coverage on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.swp
 gengo.egg-info
 gengo/test_keys.py
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ python:
 install:
   - pip install -e .[test]
 
-before_script:
-  - flake8 gengo
-
 script:
+  - flake8 gengo
   - nosetests --rednose --with-coverage --cover-package=gengo
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ python:
   - "3.3"
   - "3.4"
 
-# command to install dependencies
 install:
-- pip install -r requirements.txt
+  - pip install -e .[test]
 
-before_script: flake8 gengo
-# command to run tests
-script: nosetests --rednose
+before_script:
+  - flake8 gengo
+
+script:
+  - nosetests --rednose --with-coverage --cover-package=gengo
 
 notifications:
   irc: "irc.freenode.net#Gengo"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Only important changes are mentioned below. See `commit log <https://github.com/
 Unreleased
 ----------
 * [Fix] Improve compatibility for Python 3 in error handling part
+* [Remove] Drop explicit support for Python 3.2
 
 
 v0.1.31 (2016-12-07)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Only important changes are mentioned below. See `commit log <https://github.com/
 Unreleased
 ----------
 * [Fix] Improve compatibility for Python 3 in error handling part
-* [Remove] Drop explicit support for Python 3.2
+* [Remove] Drop explicit support for Python 3.2 as the Requests library officially supports Python 2.6–2.7 & 3.3–3.5
 
 
 v0.1.31 (2016-12-07)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-flake8
-mock
-nose
-rednose
-requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,23 @@
 # Original Author: Ryan McGrath <http://venodesigns.net>
 
 from setuptools import setup, find_packages
+import sys
 
 # little tricky, but this is for version number is in one place.
 __version__ = 'This value will be overridden by exec.'
 exec(open('gengo/_version.py').read())
+
+extras_require = {
+    'test': [
+        'flake8',
+        'nose',
+        'rednose',
+    ]
+}
+
+# coverage doesn't support Python 3.2
+if sys.version_info < (3, 2, 0) or (3, 3, 0) <= sys.version_info:
+    extras_require['test'].append('coverage')
 
 setup(
     # Basic package information.
@@ -50,6 +63,7 @@ setup(
 
     # Package dependencies.
     install_requires=["requests >= 2.2.1"],
+    extras_require=extras_require,
 
     # Metadata for PyPI.
     author='Gengo',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@
 # Original Author: Ryan McGrath <http://venodesigns.net>
 
 from setuptools import setup, find_packages
-import sys
 
 # little tricky, but this is for version number is in one place.
 __version__ = 'This value will be overridden by exec.'
@@ -42,15 +41,12 @@ exec(open('gengo/_version.py').read())
 
 extras_require = {
     'test': [
+        'coverage',
         'flake8',
         'nose',
         'rednose',
     ]
 }
-
-# coverage doesn't support Python 3.2
-if sys.version_info < (3, 2, 0) or (3, 3, 0) <= sys.version_info:
-    extras_require['test'].append('coverage')
 
 setup(
     # Basic package information.
@@ -81,7 +77,6 @@ setup(
         'Topic :: Internet',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ]


### PR DESCRIPTION
Weekly cleanup!

Show coverage on Travis CI. Herewith we can improve coverage, it will prevent
this kind of bug witch library doesn't work specific version of Python.
https://github.com/gengo/gengo-python/pull/87

The coverage library doesn't support Python 3.2, however I don't think it is
big problem. Because theoretically the coverage is alomost same with other
Python's coverage. We can know the coverage to see an other result.
I think better than notthing.

~~I moved from requiremnts.txt to setup.py for instaalling dependencies. Because~~
~~we cannnot write version specified things in requirements.txt, but we can do it~~
~~with setup.py. We cannot install coverage with Python 3.2. So if we use~~
~~requirements.txt, CI must be failed.~~
We were using requirements.txt for developing and testing. We can do same thing 
with:

::

   pip3 install -e .[test]


gengo-python is depends on requests. However no longer it is not supporting
Python 3.2 now. We can continue to support Python 3.2 with pointing the last version of requests witch supports Python 3.2 for Python 3.2. Do you think is it okay to stop supporting Python 3.2?
https://pypi.python.org/pypi/requests/

```
% nosetests --rednose --with-coverage --cover-package=gengo
...................

Name                Stmts   Miss  Cover
---------------------------------------
gengo.py                2      0   100%
gengo/_version.py       1      0   100%
gengo/gengo.py        198     61    69%
gengo/mockdb.py         3      0   100%
---------------------------------------
TOTAL                 204     61    70%
-----------------------------------------------------------------------------
19 tests run in 3.160 seconds (19 tests passed)
```