### PR TITLE
Support newer version Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
 
 install:
   - pip install -e .[test]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Unreleased
 ----------
 * [Fix] Improve compatibility for Python 3 in error handling part
 * [Remove] Drop explicit support for Python 3.2 as the Requests library officially supports Python 2.6–2.7 & 3.3–3.5
-* [Feature] Official support Python 3.5 and 3.6
+* [Feature] Official support for Python 3.5 and 3.6
 
 v0.1.31 (2016-12-07)
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Unreleased
 ----------
 * [Fix] Improve compatibility for Python 3 in error handling part
 * [Remove] Drop explicit support for Python 3.2 as the Requests library officially supports Python 2.6–2.7 & 3.3–3.5
-
+* [Feature] Official support Python 3.5 and 3.6
 
 v0.1.31 (2016-12-07)
 --------------------

--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )


### PR DESCRIPTION
Weekly cleanup!

Recentlly, Python 3.6 was released. Let's support it!
And we didn't support 3.5, but I think this is opportunity, Let's support it too.