### PR TITLE
Test Syntax of reRestructuredText docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
 script:
   - flake8 gengo
   - nosetests --rednose --with-coverage --cover-package=gengo
-  - rst2html.py README.rst --exit-status=2
-  - rst2html.py CHANGELOG.rst --exit-status=2
+  - rst2html.py README.rst --exit-status=2 > /dev/null
+  - rst2html.py CHANGELOG.rst --exit-status=2 > /dev/null
 
 notifications:
   irc: "irc.freenode.net#Gengo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
 script:
   - flake8 gengo
   - nosetests --rednose --with-coverage --cover-package=gengo
+  - rst2html.py README.rst --exit-status=2
+  - rst2html.py CHANGELOG.rst --exit-status=2
 
 notifications:
   irc: "irc.freenode.net#Gengo"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,16 +19,16 @@ v0.1.31 (2016-12-07)
 * [Fix] Fix compatibletext issue for Python 2.x
 
 v0.1.30 (2016-10-13)
--------------------
+--------------------
 * [Feature] `#76 <https://github.com/gengo/gengo-python/pull/76>`_ Don't require specific version of requests
 
 v0.1.29 (2016-09-30)
--------------------
+--------------------
 * [Feature] `#74 <https://github.com/gengo/gengo-python/pull/74>`_ Add support for account/me endpoint
 * [Fix] `#73 <https://github.com/gengo/gengo-python/pull/73>`_ Removed library support for Gengo API version 1.1, which is no longer supported
 
 v0.1.28 (2015-10-07)
--------------------
+--------------------
 
 * [Feature] `#59 <https://github.com/gengo/gengo-python/pull/59>`_ Add attachments support for Order and Job comments
 
@@ -39,29 +39,29 @@ v0.1.27
 * We skipped it.
 
 v0.1.26 (2015-07-14)
--------------------
+--------------------
 
 * [Fix] `#55 <https://github.com/gengo/gengo-python/pull/54>`_ Updated changelog
 
 
 v0.1.25 (2015-07-13)
--------------------
+--------------------
 
 * [Fix] `#54 <https://github.com/gengo/gengo-python/pull/54>`_ Fixed URL for GET and POST endpoints for Order comments
 
 v0.1.24 (2015-07-07)
--------------------
+--------------------
 
 * [Feature] `#53 <https://github.com/gengo/gengo-python/pull/53>`_ Added GET and POST endpoints for Order comments
 
 v0.1.17 (2014-06-18)
--------------------
+--------------------
 
 * [Fix] Fixes `#39 <https://github.com/gengo/gengo-python/pull/39>`_ Allow unknown error codes
 
 
 v0.1.16 (2014-06-16)
--------------------
+--------------------
 
 * [Fix] Set default mimetype if undetectable
 * [Fix] Update requests library dependency

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ extras_require = {
         'docutils',
         'flake8',
         'nose',
+        'Pygments',
         'rednose',
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ exec(open('gengo/_version.py').read())
 extras_require = {
     'test': [
         'coverage',
+        'docutils',
         'flake8',
         'nose',
         'rednose',


### PR DESCRIPTION
We can prevent broken reStructuredText with this change.
If we upload this library with broken it, PyPI cannot show a description of this library.

--exit=status: (choose from 'info', '1', 'warning', '2', 'error', '3', 'severe', '4', 'none', '5')
