### PR TITLE
[#58] Link to CHANGELOG from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ somewhat tricky problem to solve. `Gengo <http://gengo.com/>`_ is a service that
 (which is often of higher quality than machine translation), and an API to manage sending in work and watching
 jobs. This is a Python interface to make using the API simpler.
 
+`CHANGELOG is here <https://github.com/gengo/gengo-python/blob/master/CHANGELOG.rst>`_
+
 Installation & Requirements
 ---------------------------
 Installing this library using pip is very simple:


### PR DESCRIPTION
We got this request over an year ago. https://github.com/gengo/gengo-python/issues/58
Now we are writing CHANGELOG. This pull request make a link to CHANGELOG fro README.
Then anyone can know our changes when they find this library on PyPI.

After merge this one, I think we can close that issue. What do you guys think?