### PR TITLE
remove pprint in example for consistency

### DIFF
--- a/examples/getServiceLanguages.py
+++ b/examples/getServiceLanguages.py
@@ -35,7 +35,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from gengo import Gengo
-from pprint import pprint
 
 gengo = Gengo(
     public_key='your public key',
@@ -44,5 +43,5 @@ gengo = Gengo(
     debug=True
 )
 
-# Pretty-print a list of every supported language
-pprint(gengo.getServiceLanguages())
+# Prints a list of all supported languages in Gengo
+print(gengo.getServiceLanguages())


### PR DESCRIPTION
Just a small cleanup on one of our example file.

I noticed that this was the only one using `pprint` somewhat. 

For, mainly, consistency with others, i kept it as `print` instead 🙇 


> I couldn't really see a huge point in using `pprint` in this case

