### PR TITLE
Deprecated branch message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 # command to install dependencies
 install:
-- pip install -r requirements.txt --use-mirrors
+- pip install -r requirements.txt
 
 # command to run pep8
 before_script: python setup.py pep8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [Important] Deprecated Branch
 ======================================================================================================================================================
-[Master branch](https://github.com/gengo/gengo-python) is supporting both Python 2 and 3. No longer you don't need to use this branch for Python 3.
+[Master branch](https://github.com/gengo/gengo-python) is supporting both Python 2 and 3. You no longer need to use this branch for Python 3.
 We are going to delete this branch after the end of July 2017.
 
 [![Build Status](https://secure.travis-ci.org/gengo/gengo-python.png)](http://travis-ci.org/gengo/gengo-python)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[Important] Deprecated Branch
+======================================================================================================================================================
+[Master branch](https://github.com/gengo/gengo-python) is supporting both Python 2 and 3. No longer you don't need to use this branch for Python 3.
+We are going to delete this branch after the end of July 2017.
+
 [![Build Status](https://secure.travis-ci.org/gengo/gengo-python.png)](http://travis-ci.org/gengo/gengo-python)
 
 Gengo Python Library (for the [Gengo API](http://gengo.com/api/))


### PR DESCRIPTION
This is not for master branch!

Repeat README: `Master branch is supporting both Python 2 and 3. No longer you don't need to use this branch for Python 3.`

I set deadline at the end of July 2017. It is over half an year. I think it's enough. What do you think?